### PR TITLE
docs: add resume build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Resume Build Instructions
+
+This repository contains `resume.tex`, the source of the resume, and the generated `resume.pdf`.
+
+## Build
+
+Ensure `pdflatex` is installed and available on your `PATH` (e.g., via TeX Live).
+
+To rebuild the PDF after editing the LaTeX source, run:
+
+```bash
+./build_resume.sh
+```
+
+The script runs `pdflatex` with options to halt on errors, producing an updated `resume.pdf`.

--- a/build_resume.sh
+++ b/build_resume.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compile resume.tex into resume.pdf using pdflatex.
+pdflatex -interaction=nonstopmode -halt-on-error resume.tex


### PR DESCRIPTION
## Summary
- add `build_resume.sh` script using pdflatex to produce `resume.pdf`
- document resume build steps in README

## Testing
- `./build_resume.sh` *(fails: pdflatex: command not found)*
- `apt-get update` *(fails: repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689754589b38832c8c84b19e0cf0c1ac