### PR TITLE
Add multipage portfolio template

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinod Kumar Gorrepati</title>
+  <title>About - Vinod Kumar Gorrepati</title>
   <link rel="stylesheet" href="styles.css">
   <script defer src="script.js"></script>
 </head>
@@ -28,14 +28,12 @@
       </div>
     </div>
   </header>
-
   <main>
-    <section>
-      <h2>Welcome</h2>
-      <p>Use the navigation above to explore the site and add your details to each section.</p>
+    <section id="about">
+      <h2>About</h2>
+      <p>Add your background and experience details here.</p>
     </section>
   </main>
-
   <footer role="contentinfo">
     © 2025 Vinod Kumar Gorrepati
   </footer>

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinod Kumar Gorrepati</title>
+  <title>Contact - Vinod Kumar Gorrepati</title>
   <link rel="stylesheet" href="styles.css">
   <script defer src="script.js"></script>
 </head>
@@ -28,14 +28,23 @@
       </div>
     </div>
   </header>
-
   <main>
-    <section>
-      <h2>Welcome</h2>
-      <p>Use the navigation above to explore the site and add your details to each section.</p>
+    <section id="contact">
+      <h2>Contact</h2>
+      <form class="contact-form" action="mailto:vinodkumar1947@gmail.com" method="POST">
+        <label>Name
+          <input type="text" name="name" required>
+        </label>
+        <label>Email
+          <input type="email" name="email" required>
+        </label>
+        <label>Message
+          <textarea name="message" rows="5" required></textarea>
+        </label>
+        <button type="submit">Send</button>
+      </form>
     </section>
   </main>
-
   <footer role="contentinfo">
     © 2025 Vinod Kumar Gorrepati
   </footer>

--- a/projects.html
+++ b/projects.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinod Kumar Gorrepati</title>
+  <title>Projects - Vinod Kumar Gorrepati</title>
   <link rel="stylesheet" href="styles.css">
   <script defer src="script.js"></script>
 </head>
@@ -28,14 +28,19 @@
       </div>
     </div>
   </header>
-
   <main>
-    <section>
-      <h2>Welcome</h2>
-      <p>Use the navigation above to explore the site and add your details to each section.</p>
+    <section id="projects">
+      <h2>Projects</h2>
+      <div class="project-grid">
+        <article class="project">
+          <h3>Project Title</h3>
+          <p>Describe your project here.</p>
+          <a href="#" target="_blank" rel="noopener">Source</a>
+        </article>
+        <!-- Add more projects here -->
+      </div>
     </section>
   </main>
-
   <footer role="contentinfo">
     © 2025 Vinod Kumar Gorrepati
   </footer>

--- a/resume.html
+++ b/resume.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinod Kumar Gorrepati</title>
+  <title>Resume - Vinod Kumar Gorrepati</title>
   <link rel="stylesheet" href="styles.css">
   <script defer src="script.js"></script>
 </head>
@@ -28,14 +28,12 @@
       </div>
     </div>
   </header>
-
   <main>
-    <section>
-      <h2>Welcome</h2>
-      <p>Use the navigation above to explore the site and add your details to each section.</p>
+    <section id="resume">
+      <h2>Resume</h2>
+      <p><a class="btn" href="resume.pdf" target="_blank" rel="noopener">View / Download Resume</a></p>
     </section>
   </main>
-
   <footer role="contentinfo">
     © 2025 Vinod Kumar Gorrepati
   </footer>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.getElementById('theme-toggle');
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme === 'dark') {
+    document.body.classList.add('dark');
+  }
   toggle.addEventListener('click', () => {
     document.body.classList.toggle('dark');
+    localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
   });
 
   document.querySelectorAll('a[href^="#"]').forEach(anchor => {

--- a/skills.html
+++ b/skills.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinod Kumar Gorrepati</title>
+  <title>Skills - Vinod Kumar Gorrepati</title>
   <link rel="stylesheet" href="styles.css">
   <script defer src="script.js"></script>
 </head>
@@ -28,14 +28,18 @@
       </div>
     </div>
   </header>
-
   <main>
-    <section>
-      <h2>Welcome</h2>
-      <p>Use the navigation above to explore the site and add your details to each section.</p>
+    <section id="skills">
+      <h2>Skills</h2>
+      <ul class="skills-list">
+        <li>Embedded C / C++</li>
+        <li>RTOS &amp; Linux</li>
+        <li>Hardware bring-up</li>
+        <li>System design</li>
+        <!-- Add more skills here -->
+      </ul>
     </section>
   </main>
-
   <footer role="contentinfo">
     © 2025 Vinod Kumar Gorrepati
   </footer>


### PR DESCRIPTION
## Summary
- Convert single-page site into a multipage layout with dedicated About, Skills, Projects, Resume, and Contact pages.
- Enhance navigation and theme persistence for a consistent experience across pages.

## Testing
- `./build_resume.sh` *(fails: pdflatex: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689760efb1a0832cbb0c7782ab1b2faf